### PR TITLE
Fix: Handle android time with unix seconds not ms + unify API response formats

### DIFF
--- a/packages/core/android/src/main/java/net/mjstudio/rnkakao/core/util/RNCKakaoUtil.kt
+++ b/packages/core/android/src/main/java/net/mjstudio/rnkakao/core/util/RNCKakaoUtil.kt
@@ -108,28 +108,37 @@ fun WritableArray.pushMapList(list: List<WritableMap>): WritableArray {
 fun WritableMap.putBooleanIfNotNull(
   key: String,
   value: Boolean?,
-) {
+): WritableMap {
   if (value != null) {
     putBoolean(key, value)
+  } else {
+    putNull(key)
   }
+  return this
 }
 
 fun WritableMap.putIntIfNotNull(
   key: String,
   value: Int?,
-) {
+): WritableMap {
   if (value != null) {
     putInt(key, value)
+  } else {
+    putNull(key)
   }
+  return this
 }
 
 fun WritableMap.putDoubleIfNotNull(
   key: String,
   value: Double?,
-) {
+): WritableMap {
   if (value != null) {
     putDouble(key, value)
+  } else {
+    putNull(key)
   }
+  return this
 }
 
 fun argMap(): WritableMap {
@@ -177,3 +186,6 @@ object RNCKakaoUtil {
     return (d1.time - d2.time) / 1000L
   }
 }
+
+val Date.unix: Long
+  get() = time / 1000

--- a/packages/social/android/src/main/java/net/mjstudio/rnkakao/social/RNCKakaoSocialModule.kt
+++ b/packages/social/android/src/main/java/net/mjstudio/rnkakao/social/RNCKakaoSocialModule.kt
@@ -25,6 +25,7 @@ import net.mjstudio.rnkakao.core.util.getIntElseNull
 import net.mjstudio.rnkakao.core.util.onMain
 import net.mjstudio.rnkakao.core.util.pushMapList
 import net.mjstudio.rnkakao.core.util.putBooleanIfNotNull
+import net.mjstudio.rnkakao.core.util.putDoubleIfNotNull
 import net.mjstudio.rnkakao.core.util.putIntIfNotNull
 import net.mjstudio.rnkakao.core.util.rejectWith
 
@@ -84,7 +85,7 @@ class RNCKakaoSocialModule internal constructor(context: ReactApplicationContext
                   users.users?.map {
                     argMap().apply {
                       putString("uuid", it.uuid)
-                      putIntIfNotNull("id", it.id?.toInt())
+                      putDoubleIfNotNull("id", it.id?.toDouble())
                       putBooleanIfNotNull("favorite", it.favorite)
                       putString("profileNickname", it.profileNickname)
                       putString("profileThumbnailImage", it.profileThumbnailImage)
@@ -171,7 +172,7 @@ class RNCKakaoSocialModule internal constructor(context: ReactApplicationContext
                 argArr().pushMapList(
                   friends.elements!!.map {
                     argMap().apply {
-                      putIntIfNotNull("id", it.id?.toInt())
+                      putDoubleIfNotNull("id", it.id?.toDouble())
                       putString("uuid", it.uuid)
                       putString("profileNickname", it.profileNickname)
                       putString("profileThumbnailImage", it.profileThumbnailImage)

--- a/packages/user/android/src/main/java/net/mjstudio/rnkakao/user/RNCKakaoUserModule.kt
+++ b/packages/user/android/src/main/java/net/mjstudio/rnkakao/user/RNCKakaoUserModule.kt
@@ -24,7 +24,6 @@ import net.mjstudio.rnkakao.core.util.pushMapList
 import net.mjstudio.rnkakao.core.util.pushStringList
 import net.mjstudio.rnkakao.core.util.putBooleanIfNotNull
 import net.mjstudio.rnkakao.core.util.putDoubleIfNotNull
-import net.mjstudio.rnkakao.core.util.putIntIfNotNull
 import net.mjstudio.rnkakao.core.util.rejectWith
 import net.mjstudio.rnkakao.core.util.unix
 import java.util.Date
@@ -258,7 +257,7 @@ class RNCKakaoUserModule internal constructor(context: ReactApplicationContext) 
           } else {
             promise.resolve(
               argMap().apply {
-                putIntIfNotNull("userId", addrs.userId?.toInt())
+                putDoubleIfNotNull("userId", addrs.userId?.toDouble())
                 putBooleanIfNotNull("needsAgreement", addrs.needsAgreement)
                 putArray(
                   "shippingAddresses",
@@ -266,7 +265,7 @@ class RNCKakaoUserModule internal constructor(context: ReactApplicationContext) 
                     pushMapList(
                       addrs.shippingAddresses?.map { addr ->
                         argMap().apply {
-                          putInt("id", addr.id.toInt())
+                          putDouble("id", addr.id.toDouble())
                           putString("name", addr.name)
                           putBoolean("isDefault", addr.isDefault)
                           putDoubleIfNotNull("updatedAt", addr.updatedAt?.unix?.toDouble())

--- a/packages/user/android/src/main/java/net/mjstudio/rnkakao/user/RNCKakaoUserModule.kt
+++ b/packages/user/android/src/main/java/net/mjstudio/rnkakao/user/RNCKakaoUserModule.kt
@@ -26,6 +26,7 @@ import net.mjstudio.rnkakao.core.util.putBooleanIfNotNull
 import net.mjstudio.rnkakao.core.util.putDoubleIfNotNull
 import net.mjstudio.rnkakao.core.util.putIntIfNotNull
 import net.mjstudio.rnkakao.core.util.rejectWith
+import net.mjstudio.rnkakao.core.util.unix
 import java.util.Date
 
 class RNCKakaoUserModule internal constructor(context: ReactApplicationContext) :
@@ -61,11 +62,11 @@ class RNCKakaoUserModule internal constructor(context: ReactApplicationContext) 
               putString("idToken", token.idToken)
               putDouble(
                 "accessTokenExpiresAt",
-                token.accessTokenExpiresAt.time.toDouble(),
+                token.accessTokenExpiresAt.unix.toDouble(),
               )
               putDouble(
                 "refreshTokenExpiresAt",
-                token.refreshTokenExpiresAt.time.toDouble(),
+                token.refreshTokenExpiresAt.unix.toDouble(),
               )
               putDouble(
                 "accessTokenExpiresIn",
@@ -230,24 +231,17 @@ class RNCKakaoUserModule internal constructor(context: ReactApplicationContext) 
             promise.rejectWith(RNCKakaoResponseNotFoundException("serviceTerms"))
           } else {
             promise.resolve(
-              argMap().apply {
-                putArray(
-                  "allowedServiceTerms",
-                  argArr().apply {
-                    serviceTerms.serviceTerms?.forEach { term ->
-                      pushMap(
-                        argMap().apply {
-                          putString("tag", term.tag)
-                          putDoubleIfNotNull("agreedAt", term.agreedAt?.time?.toDouble())
-                          putBoolean("agreed", term.agreed)
-                          putBoolean("required", term.required)
-                          putBoolean("revocable", term.revocable)
-                        },
-                      )
-                    }
-                  },
-                )
-              },
+              argArr().pushMapList(
+                serviceTerms.serviceTerms?.map { term ->
+                  argMap().apply {
+                    putString("tag", term.tag)
+                    putDoubleIfNotNull("agreedAt", term.agreedAt?.unix?.toDouble())
+                    putBoolean("agreed", term.agreed)
+                    putBoolean("required", term.required)
+                    putBoolean("revocable", term.revocable)
+                  }
+                } ?: listOf(),
+              ),
             )
           }
         }
@@ -275,7 +269,7 @@ class RNCKakaoUserModule internal constructor(context: ReactApplicationContext) 
                           putInt("id", addr.id.toInt())
                           putString("name", addr.name)
                           putBoolean("isDefault", addr.isDefault)
-                          putDoubleIfNotNull("updatedAt", addr.updatedAt?.time?.toDouble())
+                          putDoubleIfNotNull("updatedAt", addr.updatedAt?.unix?.toDouble())
                           putString("type", addr.type?.name)
                           putString("baseAddress", addr.baseAddress)
                           putString("detailAddress", addr.detailAddress)
@@ -306,7 +300,7 @@ class RNCKakaoUserModule internal constructor(context: ReactApplicationContext) 
           } else {
             promise.resolve(
               argMap().apply {
-                putIntIfNotNull("id", user.id?.toInt())
+                putDoubleIfNotNull("id", user.id?.toDouble())
                 putString("name", user.kakaoAccount?.name)
 
                 putString("email", user.kakaoAccount?.email)


### PR DESCRIPTION
## Type of change


- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Enhance (enhance performance, api, etc)


## What does this change?

- Unify Android, iOS response about time. Android time unit in response was milliseconds not seconds.
- Match Android `serviceTerms` response with iOS.
- Android API response includes `null` fields if `putXXXElseNull` failed.
- Fix Android user ID `long` type was overflowed by casting to `Int`. It will be handled as a `double` now.

Fixes #16 🎯

![image](https://github.com/mym0404/react-native-kakao/assets/33388801/f6a82b52-2b48-4d80-9fde-383d342d8147)

![image](https://github.com/mym0404/react-native-kakao/assets/33388801/1e2eb0f4-6c7a-4b44-8442-2894a949929e)
