### PR TITLE
fix: remove unused deps `RNCKakaoUser` in social

### DIFF
--- a/packages/social/RNCKakaoSocial.podspec
+++ b/packages/social/RNCKakaoSocial.podspec
@@ -55,7 +55,6 @@ Pod::Spec.new do |s|
   end
 
   s.dependency          'RNCKakaoCore'
-  s.dependency          'RNCKakaoUser'
 
   # Kakao dependencies
   s.dependency          'KakaoSDKFriend', friend_sdk_version


### PR DESCRIPTION
<!-- Thank you for contributing package 🤗 -->

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## What does this change?
Remove the unused dependency RNCKakaoUser in the social package, which causes an error during pod install.

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->



