### PR TITLE
fix: followChannel method response in web

### DIFF
--- a/packages/channel/src/index.web.ts
+++ b/packages/channel/src/index.web.ts
@@ -17,9 +17,13 @@ declare const Kakao: {
 const KakaoChannel: KakaoChannelAPI = {
   followChannel: (channelPublicId: string): Promise<boolean> =>
     kRunWebAPI(async () => {
-      await Kakao.Channel.followChannel({ channelPublicId });
+      const result = await Kakao.Channel.followChannel({ channelPublicId });
 
-      return true;
+      if (result && channelPublicId === result.channel_public_id && result.status === 'success') {
+        return true;
+      }
+
+      return false;
     }),
   addChannel: (channelPublicId: string): Promise<void> =>
     kRunWebAPI(() => Kakao.Channel.addChannel({ channelPublicId })),


### PR DESCRIPTION
<!-- Thank you for contributing package 🤗 -->

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhance (enhance performance, api, etc)
- [ ] Chore
- [ ] This change requires a documentation update
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## What does this change?

followChannel 메서드를 웹에서 사용시 리스폰스 처리를 추가했습니다.
기존에는 채널 추가를 취소하더라도 response가 true로 반환되어, 사용자가 채널 추가를 취소했는지 판단하기 어려운 상황이었습니다. 
(아래의 상황에서 취소입니다.)

![카카오 채널 추가하기](https://github.com/user-attachments/assets/b4f808b9-1fed-4a74-9f6a-083a5c48eb12)

카카오 공식 문서를 통해 response 타입을 알아내어 개발해보았습니다. 
위의 상황에서 채널 추가를 했을 시에는 true를 반환하고, 취소한 경우나 채널 ID가 이상한 경우 false를 반환할 것입니다.
[카카오 공식 문서](https://developers.kakao.com/sdk/reference/js/release/Kakao.Channel.html#FollowChannelResponse)

