### PR TITLE
fix(android): Remove empty <activity/> injection in config plugin

### DIFF
--- a/packages/core/expo-config-plugin/src/withAndroid.ts
+++ b/packages/core/expo-config-plugin/src/withAndroid.ts
@@ -20,10 +20,6 @@ const withAndroid: ConfigPlugin<{
   config = withAndroidManifest(config, (config) => {
     const mainApplication = AndroidConfig.Manifest.getMainApplicationOrThrow(config.modResults);
 
-    mainApplication.activity?.push(<AndroidConfig.Manifest.ManifestActivity>{
-      $: {},
-    });
-
     const injectActivity = ({
       activityName,
       activity,


### PR DESCRIPTION
<!-- Thank you for contributing package 🤗 -->

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhance (enhance performance, api, etc)
- [ ] Chore
- [ ] This change requires a documentation update
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## What does this change?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

### 문제
현재 `@react-native-kakao/core`의 Expo config plugin은 AndroidManifest에 
아무 속성도 없는 `<activity/>` 태그를 삽입합니다.

```xml
<activity/>
```

이로 인해 :app:processDebugMainManifest 단계에서
Missing 'name' key attribute on element activity 오류가 발생하며
Android 빌드가 실패합니다.

### 수정
- 불필요한 dummy activity 삽입 코드를 제거했습니다.

Fixes #<issue_number_goes_here> 🎯

