### PR TITLE
fix: use correct field name for idType in CalendarTemplate on Android

### DIFF
--- a/packages/share/android/src/main/java/net/mjstudio/rnkakao/share/RNCKakaoShareTemplates.kt
+++ b/packages/share/android/src/main/java/net/mjstudio/rnkakao/share/RNCKakaoShareTemplates.kt
@@ -148,7 +148,7 @@ object RNCKakaoShareTemplates {
   private fun createCalendarTemplate(map: ReadableMap) =
     CalendarTemplate(
       id = map.getString("id")!!,
-      idType = if (map.getString("id") == "event") EVENT else CALENDAR,
+      idType = if (map.getString("idType") == "event") EVENT else CALENDAR,
       content = map.getMap("content")!!.toContent(),
       buttons = map.getArray("buttons")?.filterIsReadableMap()?.map { it.toButton() },
     )


### PR DESCRIPTION
## 설명

`RNCKakaoShareTemplates.kt` 151번 줄에서 `createCalendarTemplate`이 `idType`을 결정할 때 `map.getString("idType")` 대신 `map.getString("id")`를 비교하고 있습니다.

```kotlin
// 현재 (버그)
idType = if (map.getString("id") == "event") EVENT else CALENDAR,

// 수정
idType = if (map.getString("idType") == "event") EVENT else CALENDAR,
```

## 영향

- **Android에서만 발생** — iOS는 JSON 디코딩 방식이라 `idType` 필드가 정상적으로 매핑됩니다.
- `shareCalendarTemplate`에서 `idType: 'event'`를 전달해도 항상 `CALENDAR`로 설정됩니다.
- Kakao SDK 오류: `failed to parse parameter. name=template_object, stringToParse=, paramString=, paramStringAlias=null`

## 환경

- `@react-native-kakao/share`: 2.4.4