### PR TITLE
fix: forward OIDC nonce to native Kakao login

### DIFF
--- a/docs/docs/user/login.mdx
+++ b/docs/docs/user/login.mdx
@@ -57,6 +57,14 @@ login()
 
 - `useKakaoAccountLogin`: 항상 카카오톡이 아닌 카카오 계정으로 로그인을 시도합니다.
 
+- `nonce`: ID 토큰 재생 공격을 방지하기 위한 검증 값입니다. 전달한 값이 발급되는 ID 토큰의 `nonce` claim에 포함되어 반환됩니다.
+
+자세한 내용은 [공식 문서](https://developers.kakao.com/docs/latest/ko/kakaologin/utilize#parameter-for-security)를 참고해주세요.
+
+:::info
+OpenID Connect를 활성화한 앱에서만 의미가 있습니다.
+:::
+
 
 :::warning 경고
 다음과 같은 조건으로 사용한다면 에러를 던집니다.

--- a/docs/i18n/en/docusaurus-plugin-content-docs/current/user/login.mdx
+++ b/docs/i18n/en/docusaurus-plugin-content-docs/current/user/login.mdx
@@ -53,6 +53,14 @@ If `scopes` are provided, it always executes login with a Kakao account.
 
 -  `useKakaoAccountLogin`: Attempt login with a Kakao account instead of KakaoTalk.
 
+-  `nonce`: A value used to prevent ID token replay attacks. The value you pass is returned in the `nonce` claim of the issued ID token.
+
+Refer to the [Official Documentation](https://developers.kakao.com/docs/latest/ko/kakaologin/utilize#parameter-for-security) for details.
+
+:::info
+Only meaningful for apps with OpenID Connect enabled.
+:::
+
 :::warning Warning
 Errors will be thrown under the following conditions:
 -  If `useKakaoAccountLogin` does not exist or is `false`, `prompts` and `scopes` cannot be passed.

--- a/packages/user/android/src/main/java/net/mjstudio/rnkakao/user/RNCKakaoUserModule.kt
+++ b/packages/user/android/src/main/java/net/mjstudio/rnkakao/user/RNCKakaoUserModule.kt
@@ -40,6 +40,7 @@ class RNCKakaoUserModule internal constructor(
     prompts: ReadableArray?,
     useKakaoAccountLogin: Boolean,
     scopes: ReadableArray?,
+    nonce: String?,
     promise: Promise,
   ) = onMain {
     val context =
@@ -90,6 +91,7 @@ class RNCKakaoUserModule internal constructor(
       UserApiClient.instance.loginWithNewScopes(
         context,
         scopes = scopes.filterIsInstance<String>(),
+        nonce = nonce,
         callback = callback,
       )
     } else if (UserApiClient.instance.isKakaoTalkLoginAvailable(context) &&
@@ -100,6 +102,7 @@ class RNCKakaoUserModule internal constructor(
     ) {
       UserApiClient.instance.loginWithKakaoTalk(
         context,
+        nonce = nonce,
         serviceTerms = serviceTerms?.filterIsInstance<String>()?.ifEmpty { null },
         callback = callback,
       )
@@ -119,6 +122,7 @@ class RNCKakaoUserModule internal constructor(
                 else -> null
               }
             }?.ifEmpty { null },
+        nonce = nonce,
         serviceTerms = serviceTerms?.filterIsInstance<String>()?.ifEmpty { null },
         callback = callback,
       )

--- a/packages/user/android/src/oldarch/KakaoUserSpec.kt
+++ b/packages/user/android/src/oldarch/KakaoUserSpec.kt
@@ -13,6 +13,7 @@ abstract class KakaoUserSpec internal constructor(
     prompts: ReadableArray?,
     useKakaoAccountLogin: Boolean,
     scopes: ReadableArray?,
+    nonce: String?,
     promise: Promise,
   )
 

--- a/packages/user/ios/RNCKakaoUser.mm
+++ b/packages/user/ios/RNCKakaoUser.mm
@@ -19,12 +19,13 @@ RCT_EXPORT_METHOD(isKakaoTalkLoginAvailable : (RCTPromiseResolveBlock)
 }
 RCT_EXPORT_METHOD(login : (NSArray*)serviceTerms prompts : (NSArray*)
                       prompts useKakaoAccountLogin : (BOOL)useKakaoAccountLogin scopes : (NSArray*)
-                          scopes resolve : (RCTPromiseResolveBlock)
+                          scopes nonce : (NSString*)nonce resolve : (RCTPromiseResolveBlock)
                               resolve reject : (RCTPromiseRejectBlock)reject) {
   [[self manager] login:serviceTerms
                    prompts:prompts
       useKakaoAccountLogin:useKakaoAccountLogin
                     scopes:scopes
+                     nonce:nonce
                    resolve:resolve
                     reject:reject];
 }

--- a/packages/user/ios/RNCKakaoUserManager.swift
+++ b/packages/user/ios/RNCKakaoUserManager.swift
@@ -32,6 +32,7 @@ import RNCKakaoCore
     prompts: [String],
     useKakaoAccountLogin: Bool,
     scopes: [String],
+    nonce: String?,
     resolve: @escaping RCTPromiseResolveBlock,
     reject: @escaping RCTPromiseRejectBlock
   ) {
@@ -61,22 +62,35 @@ import RNCKakaoCore
       }
 
       if !scopes.isEmpty {
-        UserApi.shared.loginWithKakaoAccount(scopes: scopes, completion: callback)
+        UserApi.shared.loginWithKakaoAccount(scopes: scopes, nonce: nonce, completion: callback)
       } else if UserApi.isKakaoTalkLoginAvailable(), !useKakaoAccountLogin {
         UserApi.shared
-          .loginWithKakaoTalk(serviceTerms: emptyArrayToNil(serviceTerms), completion: callback)
+          .loginWithKakaoTalk(
+            serviceTerms: emptyArrayToNil(serviceTerms),
+            nonce: nonce,
+            completion: callback
+          )
       } else {
         var _prompts: [Prompt] = []
         for p in prompts {
-          if p == "Login" { _prompts.append(.Login) }
-          if p == "Cert" { _prompts.append(.Cert) }
-          if p == "Create" { _prompts.append(.Create) }
-          if p == "UnifyDaum" { _prompts.append(.UnifyDaum) }
+          if p == "Login" {
+            _prompts.append(.Login)
+          }
+          if p == "Cert" {
+            _prompts.append(.Cert)
+          }
+          if p == "Create" {
+            _prompts.append(.Create)
+          }
+          if p == "UnifyDaum" {
+            _prompts.append(.UnifyDaum)
+          }
         }
         UserApi.shared
           .loginWithKakaoAccount(
             prompts: emptyArrayToNil(_prompts),
             serviceTerms: emptyArrayToNil(serviceTerms),
+            nonce: nonce,
             completion: callback
           )
       }
@@ -313,7 +327,9 @@ import RNCKakaoCore
   }
 
   private func emptyArrayToNil<T>(_ arr: [T]?) -> [T]? {
-    if arr == nil || arr?.isEmpty == true { return nil }
+    if arr == nil || arr?.isEmpty == true {
+      return nil
+    }
     return arr
   }
 }

--- a/packages/user/src/index.ts
+++ b/packages/user/src/index.ts
@@ -120,6 +120,7 @@ export function login({
   prompts,
   useKakaoAccountLogin,
   scopes,
+  web,
 }: {
   serviceTerms?: string[];
   prompts?: ('Login' | 'Create' | 'Cert' | 'UnifyDaum' | 'SelectAccount')[];
@@ -151,6 +152,7 @@ export function login({
     prompts ?? [],
     useKakaoAccountLogin ?? false,
     scopes ?? [],
+    web?.nonce,
   );
 }
 

--- a/packages/user/src/index.ts
+++ b/packages/user/src/index.ts
@@ -120,12 +120,13 @@ export function login({
   prompts,
   useKakaoAccountLogin,
   scopes,
-  web,
+  nonce,
 }: {
   serviceTerms?: string[];
   prompts?: ('Login' | 'Create' | 'Cert' | 'UnifyDaum' | 'SelectAccount')[];
   scopes?: string[];
   useKakaoAccountLogin?: boolean;
+  nonce?: string;
   web?: {
     redirectUri: string;
     scope?: string[];
@@ -152,7 +153,7 @@ export function login({
     prompts ?? [],
     useKakaoAccountLogin ?? false,
     scopes ?? [],
-    web?.nonce,
+    nonce,
   );
 }
 

--- a/packages/user/src/index.web.ts
+++ b/packages/user/src/index.web.ts
@@ -88,7 +88,7 @@ const KakaoUser: KakaoUserAPI = {
       return Kakao.Auth.authorize(
         filterNonNullishKeys({
           loginHint,
-          nonce,
+          nonce: params?.nonce ?? nonce,
           prompt: prompt?.join(','),
           redirectUri,
           scope: scope?.join(','),

--- a/packages/user/src/spec/NativeKakaoUser.ts
+++ b/packages/user/src/spec/NativeKakaoUser.ts
@@ -17,6 +17,7 @@ export interface Spec extends TurboModule {
     prompts: string[],
     useKakaoAccountLogin: boolean,
     scopes?: string[],
+    nonce?: string,
   ): Promise<KakaoLoginToken>;
   logout(): Promise<void>;
   unlink(): Promise<void>;


### PR DESCRIPTION
<!-- Thank you for contributing package 🤗 -->

OIDC 기반 인증을 카카오 로그인과 연동하는 과정에서 `nonce` 관련 문제를 발견해, 다른
사용자분들께도 도움이 될 수 있을 것 같아 수정 사항을 제안드립니다.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## What does this change?

`login()`의 TypeScript 타입에는 `web.nonce`가 정의돼 있지만 실제로는 `Native.login()` 호출에
전달되지 않습니다. Android/iOS 네이티브 브릿지에도 `nonce` 파라미터가 없습니다.

OIDC `nonce`는 `id_token` 재전송 공격을 막기 위해 요청 시 보낸 값과 `id_token`의 `nonce` claim을
대조하는 데 쓰입니다. 지금은 이 claim이 카카오 로그인에서 항상 비어 있어서, nonce를 검증하는
백엔드에서는 로그인이 거부됩니다.

카카오 네이티브 SDK는 이미 `nonce` 파라미터를 지원합니다.
- Android: `UserApiClient.loginWithKakaoTalk/loginWithKakaoAccount/loginWithNewScopes(nonce: ...)`
- iOS: `UserApi.loginWithKakaoTalk/loginWithKakaoAccount(nonce: ...)`

리뷰 반영으로 `nonce`를 최상위 로그인 옵션으로 두고, 아래 체인 전체로 연결했습니다.

```
JS login({ nonce })
  -> TS Spec (NativeKakaoUser.ts)
  -> Kotlin module (old-arch + new-arch codegen)
  -> Swift manager (RNCKakaoUserManager.swift)
  -> Obj-C++ bridge (RNCKakaoUser.mm)
  -> loginWithKakaoTalk / loginWithKakaoAccount / loginWithNewScopes
```

웹(`index.web.ts`)도 같은 최상위 `nonce`를 우선 사용하며, 기존 `web.nonce`는 하위호환을 위해
폴백으로 동작합니다.

## Testing

- `tsc -b`, `yarn prepack`, `yarn lint`(ESLint/SwiftFormat/ktlint/ClangFormat) 모두 통과
- example 앱 iOS 실빌드 성공, 수정한 두 파일(`RNCKakaoUserManager.swift`, `RNCKakaoUser.mm`) 정상 컴파일
- 동일한 변경을 다운스트림 앱에 적용해 실기기에서 카카오 로그인 + 백엔드의 `nonce` claim 검증까지 통과 확인
- 문서는 Docusaurus 로컬 서버로 한/영 페이지 렌더링 확인

감사합니다
