### PR TITLE
fix: stabilize iOS CI toolchain

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,7 +134,13 @@ jobs:
     steps:
       - uses: maxim-lobanov/setup-xcode@v1
         with:
-          xcode-version: "26.0"
+          xcode-version: "26.2"
+      - name: Ensure iOS Simulator runtime
+        run: |
+          simulator_version=$(xcrun --sdk iphonesimulator --show-sdk-version)
+          if ! xcrun simctl list runtimes | grep -Fq "iOS ${simulator_version}"; then
+            xcodebuild -downloadPlatform iOS -buildVersion "${simulator_version}"
+          fi
       - name: Checkout
         uses: actions/checkout@v4
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -138,6 +138,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.1.2'
+
       - name: Setup
         uses: ./.github/actions/setup
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -132,9 +132,6 @@ jobs:
     env:
       TURBO_CACHE_DIR: .turbo/ios-${{matrix.arch}}
     steps:
-      - uses: maxim-lobanov/setup-xcode@v1
-        with:
-          xcode-version: "26.0"
       - name: Checkout
         uses: actions/checkout@v4
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -132,6 +132,9 @@ jobs:
     env:
       TURBO_CACHE_DIR: .turbo/ios-${{matrix.arch}}
     steps:
+      - uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: "26.0"
       - name: Checkout
         uses: actions/checkout@v4
 

--- a/script/ci-ios-build.sh
+++ b/script/ci-ios-build.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 
-cd example/ios && xcodebuild -workspace KakaoExample.xcworkspace -scheme KakaoExample -configuration Debug -sdk iphonesimulator -quiet CC=clang CPLUSPLUS=clang++ LD=clang LDPLUSPLUS=clang++ GCC_OPTIMIZATION_LEVEL=0 GCC_PRECOMPILE_PREFIX_HEADER=YES ASSETCATALOG_COMPILER_OPTIMIZATION=time DEBUG_INFORMATION_FORMAT=dwarf COMPILER_INDEX_STORE_ENABLE=NO ONLY_ACTIVE_ARCH=YES
+cd example/ios && xcodebuild -workspace KakaoExample.xcworkspace -scheme KakaoExample -configuration Debug -sdk iphoneos -destination 'generic/platform=iOS' -quiet CODE_SIGNING_ALLOWED=NO CC=clang CPLUSPLUS=clang++ LD=clang LDPLUSPLUS=clang++ GCC_OPTIMIZATION_LEVEL=0 GCC_PRECOMPILE_PREFIX_HEADER=YES ASSETCATALOG_COMPILER_OPTIMIZATION=time DEBUG_INFORMATION_FORMAT=dwarf COMPILER_INDEX_STORE_ENABLE=NO ONLY_ACTIVE_ARCH=YES

--- a/script/ci-ios-build.sh
+++ b/script/ci-ios-build.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 
-cd example/ios && xcodebuild -workspace KakaoExample.xcworkspace -scheme KakaoExample -configuration Debug -sdk iphoneos -destination 'generic/platform=iOS' -quiet CODE_SIGNING_ALLOWED=NO CC=clang CPLUSPLUS=clang++ LD=clang LDPLUSPLUS=clang++ GCC_OPTIMIZATION_LEVEL=0 GCC_PRECOMPILE_PREFIX_HEADER=YES ASSETCATALOG_COMPILER_OPTIMIZATION=time DEBUG_INFORMATION_FORMAT=dwarf COMPILER_INDEX_STORE_ENABLE=NO ONLY_ACTIVE_ARCH=YES
+cd example/ios && xcodebuild -workspace KakaoExample.xcworkspace -scheme KakaoExample -configuration Debug -sdk iphonesimulator -quiet CC=clang CPLUSPLUS=clang++ LD=clang LDPLUSPLUS=clang++ GCC_OPTIMIZATION_LEVEL=0 GCC_PRECOMPILE_PREFIX_HEADER=YES ASSETCATALOG_COMPILER_OPTIMIZATION=time DEBUG_INFORMATION_FORMAT=dwarf COMPILER_INDEX_STORE_ENABLE=NO ONLY_ACTIVE_ARCH=YES


### PR DESCRIPTION
## Overview

- Pin Ruby 3.1.2 in the iOS CI job so CocoaPods does not use the runner's incompatible Ruby 3.4 default.
- Select Xcode 26.2, which matches an installed iOS Simulator runtime on the current runner image.
- Verify the matching Simulator runtime before checkout and download it when the runner image does not provide it.

## Verification

- [x] Parse `.github/workflows/ci.yml` with Ruby YAML
- [x] Validate the Simulator runtime fallback with `bash -n`
- [x] Run `git diff --check`
- [x] Confirm Ruby setup and CocoaPods installation pass in GitHub Actions
- [x] Confirm the updated GitHub Actions iOS build passes