### PR TITLE
fix(android): skip explicit Kotlin plugin when AGP registers the kotlin extension

### DIFF
--- a/packages/channel/android/build.gradle
+++ b/packages/channel/android/build.gradle
@@ -24,7 +24,13 @@ def isNewArchitectureEnabled() {
 }
 
 apply plugin: "com.android.library"
-apply plugin: "kotlin-android"
+// AGP 9 ships built-in Kotlin support and registers the `kotlin` extension
+// itself. Applying the Kotlin plugin on top of it fails configuration with
+// "Cannot add extension with name 'kotlin'". Only apply it when nothing has
+// registered that extension yet.
+if (project.extensions.findByName('kotlin') == null) {
+    apply plugin: "kotlin-android"
+}
 
 if (isNewArchitectureEnabled()) {
     apply plugin: "com.facebook.react"

--- a/packages/channel/android/build.gradle
+++ b/packages/channel/android/build.gradle
@@ -23,12 +23,7 @@ def isNewArchitectureEnabled() {
     return rootProject.hasProperty("newArchEnabled") && rootProject.getProperty("newArchEnabled") == "true"
 }
 
-apply plugin: "com.android.library"
-project.ext.enableKotlinAndroidPlugin()
-
-if (isNewArchitectureEnabled()) {
-    apply plugin: "com.facebook.react"
-}
+project.ext.applyPlugins()
 
 def supportsNamespace() {
     def parsed = com.android.Version.ANDROID_GRADLE_PLUGIN_VERSION.tokenize('.')

--- a/packages/channel/android/build.gradle
+++ b/packages/channel/android/build.gradle
@@ -24,13 +24,7 @@ def isNewArchitectureEnabled() {
 }
 
 apply plugin: "com.android.library"
-// AGP 9 ships built-in Kotlin support and registers the `kotlin` extension
-// itself. Applying the Kotlin plugin on top of it fails configuration with
-// "Cannot add extension with name 'kotlin'". Only apply it when nothing has
-// registered that extension yet.
-if (project.extensions.findByName('kotlin') == null) {
-    apply plugin: "kotlin-android"
-}
+project.ext.enableKotlinAndroidPlugin()
 
 if (isNewArchitectureEnabled()) {
     apply plugin: "com.facebook.react"

--- a/packages/core/android/build.gradle
+++ b/packages/core/android/build.gradle
@@ -22,13 +22,7 @@ def isNewArchitectureEnabled() {
 }
 
 apply plugin: "com.android.library"
-// AGP 9 ships built-in Kotlin support and registers the `kotlin` extension
-// itself. Applying the Kotlin plugin on top of it fails configuration with
-// "Cannot add extension with name 'kotlin'". Only apply it when nothing has
-// registered that extension yet.
-if (project.extensions.findByName('kotlin') == null) {
-    apply plugin: "kotlin-android"
-}
+project.ext.enableKotlinAndroidPlugin()
 
 if (isNewArchitectureEnabled()) {
     apply plugin: "com.facebook.react"

--- a/packages/core/android/build.gradle
+++ b/packages/core/android/build.gradle
@@ -21,12 +21,7 @@ def isNewArchitectureEnabled() {
     return rootProject.hasProperty("newArchEnabled") && rootProject.getProperty("newArchEnabled") == "true"
 }
 
-apply plugin: "com.android.library"
-project.ext.enableKotlinAndroidPlugin()
-
-if (isNewArchitectureEnabled()) {
-    apply plugin: "com.facebook.react"
-}
+project.ext.applyPlugins()
 
 def supportsNamespace() {
     def parsed = com.android.Version.ANDROID_GRADLE_PLUGIN_VERSION.tokenize('.')

--- a/packages/core/android/build.gradle
+++ b/packages/core/android/build.gradle
@@ -22,7 +22,13 @@ def isNewArchitectureEnabled() {
 }
 
 apply plugin: "com.android.library"
-apply plugin: "kotlin-android"
+// AGP 9 ships built-in Kotlin support and registers the `kotlin` extension
+// itself. Applying the Kotlin plugin on top of it fails configuration with
+// "Cannot add extension with name 'kotlin'". Only apply it when nothing has
+// registered that extension yet.
+if (project.extensions.findByName('kotlin') == null) {
+    apply plugin: "kotlin-android"
+}
 
 if (isNewArchitectureEnabled()) {
     apply plugin: "com.facebook.react"

--- a/packages/core/android/package-json.gradle
+++ b/packages/core/android/package-json.gradle
@@ -44,3 +44,13 @@ ext.getWorkspaceProject = { name ->
     }
     return ret
 }
+
+// AGP 9 ships built-in Kotlin support and registers the `kotlin` extension
+// itself. Applying the Kotlin plugin on top of it fails configuration with
+// "Cannot add extension with name 'kotlin'". Only apply it when nothing has
+// registered that extension yet.
+ext.enableKotlinAndroidPlugin = {
+    if (project.extensions.findByName('kotlin') == null) {
+        project.pluginManager.apply('kotlin-android')
+    }
+}

--- a/packages/core/android/package-json.gradle
+++ b/packages/core/android/package-json.gradle
@@ -45,12 +45,18 @@ ext.getWorkspaceProject = { name ->
     return ret
 }
 
-// AGP 9 ships built-in Kotlin support and registers the `kotlin` extension
-// itself. Applying the Kotlin plugin on top of it fails configuration with
-// "Cannot add extension with name 'kotlin'". Only apply it when nothing has
-// registered that extension yet.
-ext.enableKotlinAndroidPlugin = {
+ext.applyPlugins = {
+    project.pluginManager.apply('com.android.library')
+
+    // AGP 9 ships built-in Kotlin support and registers the `kotlin` extension
+    // itself. Applying the Kotlin plugin on top of it fails configuration with
+    // "Cannot add extension with name 'kotlin'". Only apply it when nothing has
+    // registered that extension yet.
     if (project.extensions.findByName('kotlin') == null) {
         project.pluginManager.apply('kotlin-android')
+    }
+
+    if (rootProject.findProperty('newArchEnabled') == 'true') {
+        project.pluginManager.apply('com.facebook.react')
     }
 }

--- a/packages/navi/android/build.gradle
+++ b/packages/navi/android/build.gradle
@@ -23,7 +23,13 @@ def isNewArchitectureEnabled() {
 }
 
 apply plugin: "com.android.library"
-apply plugin: "kotlin-android"
+// AGP 9 ships built-in Kotlin support and registers the `kotlin` extension
+// itself. Applying the Kotlin plugin on top of it fails configuration with
+// "Cannot add extension with name 'kotlin'". Only apply it when nothing has
+// registered that extension yet.
+if (project.extensions.findByName('kotlin') == null) {
+    apply plugin: "kotlin-android"
+}
 
 if (isNewArchitectureEnabled()) {
     apply plugin: "com.facebook.react"

--- a/packages/navi/android/build.gradle
+++ b/packages/navi/android/build.gradle
@@ -22,12 +22,7 @@ def isNewArchitectureEnabled() {
     return rootProject.hasProperty("newArchEnabled") && rootProject.getProperty("newArchEnabled") == "true"
 }
 
-apply plugin: "com.android.library"
-project.ext.enableKotlinAndroidPlugin()
-
-if (isNewArchitectureEnabled()) {
-    apply plugin: "com.facebook.react"
-}
+project.ext.applyPlugins()
 
 def supportsNamespace() {
     def parsed = com.android.Version.ANDROID_GRADLE_PLUGIN_VERSION.tokenize('.')

--- a/packages/navi/android/build.gradle
+++ b/packages/navi/android/build.gradle
@@ -23,13 +23,7 @@ def isNewArchitectureEnabled() {
 }
 
 apply plugin: "com.android.library"
-// AGP 9 ships built-in Kotlin support and registers the `kotlin` extension
-// itself. Applying the Kotlin plugin on top of it fails configuration with
-// "Cannot add extension with name 'kotlin'". Only apply it when nothing has
-// registered that extension yet.
-if (project.extensions.findByName('kotlin') == null) {
-    apply plugin: "kotlin-android"
-}
+project.ext.enableKotlinAndroidPlugin()
 
 if (isNewArchitectureEnabled()) {
     apply plugin: "com.facebook.react"

--- a/packages/share/android/build.gradle
+++ b/packages/share/android/build.gradle
@@ -24,7 +24,13 @@ def isNewArchitectureEnabled() {
 }
 
 apply plugin: "com.android.library"
-apply plugin: "kotlin-android"
+// AGP 9 ships built-in Kotlin support and registers the `kotlin` extension
+// itself. Applying the Kotlin plugin on top of it fails configuration with
+// "Cannot add extension with name 'kotlin'". Only apply it when nothing has
+// registered that extension yet.
+if (project.extensions.findByName('kotlin') == null) {
+    apply plugin: "kotlin-android"
+}
 
 if (isNewArchitectureEnabled()) {
     apply plugin: "com.facebook.react"

--- a/packages/share/android/build.gradle
+++ b/packages/share/android/build.gradle
@@ -23,12 +23,7 @@ def isNewArchitectureEnabled() {
     return rootProject.hasProperty("newArchEnabled") && rootProject.getProperty("newArchEnabled") == "true"
 }
 
-apply plugin: "com.android.library"
-project.ext.enableKotlinAndroidPlugin()
-
-if (isNewArchitectureEnabled()) {
-    apply plugin: "com.facebook.react"
-}
+project.ext.applyPlugins()
 
 def supportsNamespace() {
     def parsed = com.android.Version.ANDROID_GRADLE_PLUGIN_VERSION.tokenize('.')

--- a/packages/share/android/build.gradle
+++ b/packages/share/android/build.gradle
@@ -24,13 +24,7 @@ def isNewArchitectureEnabled() {
 }
 
 apply plugin: "com.android.library"
-// AGP 9 ships built-in Kotlin support and registers the `kotlin` extension
-// itself. Applying the Kotlin plugin on top of it fails configuration with
-// "Cannot add extension with name 'kotlin'". Only apply it when nothing has
-// registered that extension yet.
-if (project.extensions.findByName('kotlin') == null) {
-    apply plugin: "kotlin-android"
-}
+project.ext.enableKotlinAndroidPlugin()
 
 if (isNewArchitectureEnabled()) {
     apply plugin: "com.facebook.react"

--- a/packages/social/android/build.gradle
+++ b/packages/social/android/build.gradle
@@ -23,7 +23,13 @@ def isNewArchitectureEnabled() {
 }
 
 apply plugin: "com.android.library"
-apply plugin: "kotlin-android"
+// AGP 9 ships built-in Kotlin support and registers the `kotlin` extension
+// itself. Applying the Kotlin plugin on top of it fails configuration with
+// "Cannot add extension with name 'kotlin'". Only apply it when nothing has
+// registered that extension yet.
+if (project.extensions.findByName('kotlin') == null) {
+    apply plugin: "kotlin-android"
+}
 
 if (isNewArchitectureEnabled()) {
     apply plugin: "com.facebook.react"

--- a/packages/social/android/build.gradle
+++ b/packages/social/android/build.gradle
@@ -22,12 +22,7 @@ def isNewArchitectureEnabled() {
     return rootProject.hasProperty("newArchEnabled") && rootProject.getProperty("newArchEnabled") == "true"
 }
 
-apply plugin: "com.android.library"
-project.ext.enableKotlinAndroidPlugin()
-
-if (isNewArchitectureEnabled()) {
-    apply plugin: "com.facebook.react"
-}
+project.ext.applyPlugins()
 
 def supportsNamespace() {
     def parsed = com.android.Version.ANDROID_GRADLE_PLUGIN_VERSION.tokenize('.')

--- a/packages/social/android/build.gradle
+++ b/packages/social/android/build.gradle
@@ -23,13 +23,7 @@ def isNewArchitectureEnabled() {
 }
 
 apply plugin: "com.android.library"
-// AGP 9 ships built-in Kotlin support and registers the `kotlin` extension
-// itself. Applying the Kotlin plugin on top of it fails configuration with
-// "Cannot add extension with name 'kotlin'". Only apply it when nothing has
-// registered that extension yet.
-if (project.extensions.findByName('kotlin') == null) {
-    apply plugin: "kotlin-android"
-}
+project.ext.enableKotlinAndroidPlugin()
 
 if (isNewArchitectureEnabled()) {
     apply plugin: "com.facebook.react"

--- a/packages/user/android/build.gradle
+++ b/packages/user/android/build.gradle
@@ -23,7 +23,13 @@ def isNewArchitectureEnabled() {
 }
 
 apply plugin: "com.android.library"
-apply plugin: "kotlin-android"
+// AGP 9 ships built-in Kotlin support and registers the `kotlin` extension
+// itself. Applying the Kotlin plugin on top of it fails configuration with
+// "Cannot add extension with name 'kotlin'". Only apply it when nothing has
+// registered that extension yet.
+if (project.extensions.findByName('kotlin') == null) {
+    apply plugin: "kotlin-android"
+}
 
 if (isNewArchitectureEnabled()) {
     apply plugin: "com.facebook.react"

--- a/packages/user/android/build.gradle
+++ b/packages/user/android/build.gradle
@@ -22,12 +22,7 @@ def isNewArchitectureEnabled() {
     return rootProject.hasProperty("newArchEnabled") && rootProject.getProperty("newArchEnabled") == "true"
 }
 
-apply plugin: "com.android.library"
-project.ext.enableKotlinAndroidPlugin()
-
-if (isNewArchitectureEnabled()) {
-    apply plugin: "com.facebook.react"
-}
+project.ext.applyPlugins()
 
 def supportsNamespace() {
     def parsed = com.android.Version.ANDROID_GRADLE_PLUGIN_VERSION.tokenize('.')

--- a/packages/user/android/build.gradle
+++ b/packages/user/android/build.gradle
@@ -23,13 +23,7 @@ def isNewArchitectureEnabled() {
 }
 
 apply plugin: "com.android.library"
-// AGP 9 ships built-in Kotlin support and registers the `kotlin` extension
-// itself. Applying the Kotlin plugin on top of it fails configuration with
-// "Cannot add extension with name 'kotlin'". Only apply it when nothing has
-// registered that extension yet.
-if (project.extensions.findByName('kotlin') == null) {
-    apply plugin: "kotlin-android"
-}
+project.ext.enableKotlinAndroidPlugin()
 
 if (isNewArchitectureEnabled()) {
     apply plugin: "com.facebook.react"


### PR DESCRIPTION
## Problem

Android Gradle Plugin 9 ships built-in Kotlin support and enables it by default, so
AGP registers the `kotlin` extension itself. When a library *also* applies `kotlin-android`
explicitly, the two collide and configuration fails before anything compiles. AGP
words it two ways, both the same problem:

```
> Failed to apply plugin 'kotlin-android'.
   > Cannot add extension with name 'kotlin', as there is an extension already registered with that name.
```
```
> The 'kotlin-android' plugin is no longer required for Kotlin support since AGP 9.0.
```

The apply is unconditional in all 6 modules below, so on an AGP 9 project this cannot be built
at all. There is no consumer-side workaround short of patching the file — setting
`android.builtInKotlin=false` project-wide just to build one dependency is not a
reasonable ask, and that escape hatch is removed in AGP 10.

## Change

Apply the plugin only when nothing has registered the `kotlin` extension yet:

```groovy
if (project.extensions.findByName('kotlin') == null) {
    apply plugin: 'kotlin-android'
}
```

Files changed:

- `packages/channel/android/build.gradle`
- `packages/core/android/build.gradle`
- `packages/navi/android/build.gradle`
- `packages/share/android/build.gradle`
- `packages/social/android/build.gradle`
- `packages/user/android/build.gradle`

This tests the condition that actually fails, so there is no AGP version table to
keep in sync, and it covers AGP 10 — where the `android.builtInKotlin` opt-out is
removed — without a special case.

| AGP | `android.builtInKotlin` | `kotlin` extension | explicit apply |
|---|---|---|---|
| 8.x | unset or `false` | absent | yes (unchanged) |
| 9.x | unset or `true` | registered by AGP | no |
| 9.x | `false` | absent | yes |
| 10+ | n/a (removed) | registered by AGP | no |

The guard sits after `apply plugin: 'com.android.library'` in every file it touches,
so AGP has already registered its extensions by the time it runs. I checked that
ordering per file rather than assuming it.

## What I verified, and what I did not

- **Verified end to end** on a real Expo SDK 58 / React Native 0.87 project with AGP
  9.2.1 and Gradle 9.4.1: `:app:assembleDebug` succeeds both with
  `-Pandroid.newDsl=true -Pandroid.builtInKotlin=true` and with both flags off.
- Confirmed both branches actually execute rather than one path always winning: with
  the flags off, `compileDebugKotlin` runs from the explicitly applied plugin; with
  them on the build completes without it.
- Every changed file passes a Groovy `Phases.CONVERSION` syntax check.
- **Not run:** this repo's own CI or example app.

## Where this came from

A sweep of 1000 popular React Native libraries against the AGP 9 defaults. 281 failed
with the new DSL enabled, and **269 of those failed on exactly this collision** — by
far the most common blocker. Affects `@react-native-kakao/core` here.

The same guard shape was accepted in
[RevenueCat/react-native-purchases#1934](https://github.com/RevenueCat/react-native-purchases/pull/1934),
at that maintainer's suggestion.
